### PR TITLE
Update `gulp-closure-compiler` to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "google-closure-library": "https://github.com/google/closure-library/tarball/master",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "2.3.1",
-    "gulp-closure-compiler": "0.2.17",
+    "gulp-closure-compiler": "0.4.0",
     "gulp-closure-deps": "0.4.0",
     "gulp-concat": "2.5.2",
     "gulp-connect": "3.2.2",


### PR DESCRIPTION
[A few changes](https://github.com/steida/gulp-closure-compiler/commits/e8c1acb) since 0.2.17; most notably the temporary output file now gets deleted automatically — otherwise it leaves `site.min.js` sitting around in your working tree.
